### PR TITLE
Issue #82: Fix false positives and false negatives in sshd MaxAuthTries

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -637,7 +637,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: 'Set SSH MaxAuthTries to 4 or Less (Scored)'
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -637,7 +637,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: 'Set SSH MaxAuthTries to 4 or Less (Scored)'
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -562,8 +562,9 @@ grep:
       data:
         'Amazon Linux*':
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
@@ -675,7 +675,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: 'Set SSH MaxAuthTries to 4 or Less'
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -723,7 +723,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.5
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Ensure SSH MaxAuthTries is set to 4 or less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
@@ -333,8 +333,9 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-6.2.5
       description: Set SSH MaxAuthTries to 4 or Less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -598,8 +598,9 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -601,8 +601,9 @@ h.com'
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/coreos-level-1.yaml
+++ b/hubblestack_nova_profiles/cis/coreos-level-1.yaml
@@ -549,8 +549,9 @@ grep:
       data:
         '*CoreOS*':
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/debian-7.yaml
+++ b/hubblestack_nova_profiles/cis/debian-7.yaml
@@ -183,7 +183,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Set SSH MaxAuthTries to 4 or Less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
@@ -204,7 +204,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Set SSH MaxAuthTries to 4 or Less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/debian-9.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9.yaml
@@ -192,7 +192,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Set SSH MaxAuthTries to 4 or Less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
@@ -352,8 +352,9 @@ grep:
       data:
         Red Hat Enterprise Linux Server-5:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-6.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
@@ -339,8 +339,9 @@ grep:
       data:
         Red Hat Enterprise Linux Server-6:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-6.2.5
       description: Set SSH MaxAuthTries to 4 or Less (Scored)
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -723,7 +723,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.5
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Ensure SSH MaxAuthTries is set to 4 or less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
@@ -333,8 +333,9 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-6.2.5
       description: Set SSH MaxAuthTries to 4 or Less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -591,8 +591,9 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -581,8 +581,9 @@ grep:
       data:
         Red Hat Enterprise Linux Workstation-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
@@ -230,7 +230,8 @@ grep:
         Ubuntu-12.04:
         - /etc/ssh/sshd_config:
             pattern: MaxAuthTries
-            match: '4'
+            match_output_regex: True
+            match_output: "^MaxAuthTries +[1-4]$"
             tag: CIS-9.3.5
       description: Set SSH MaxAuthTries to 4 or Less
     ssh_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
@@ -253,7 +253,8 @@ grep:
         Ubuntu-14.04:
         - /etc/ssh/sshd_config:
             pattern: MaxAuthTries
-            match: '4'
+            match_output_regex: True
+            match_output: "^MaxAuthTries +[1-4]$"
             tag: CIS-9.3.5
       description: Set SSH MaxAuthTries to 4 or Less
     ssh_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -230,7 +230,8 @@ grep:
         Ubuntu-16.04:
         - /etc/ssh/sshd_config:
             pattern: MaxAuthTries
-            match: '4'
+            match_output_regex: True
+            match_output: "^MaxAuthTries +[1-4]$"
             tag: CIS-9.3.5
       description: Set SSH MaxAuthTries to 4 or Less
     ssh_ignore_rhosts:


### PR DESCRIPTION
On branch issue82
	modified:   amazon-201409-level-1-scored-v1-0-0.yaml
	modified:   amazon-level-1-scored-v1-0-0.yaml
	modified:   amazon-level-1-scored-v2-0-0.yaml
	modified:   centos-6-level-1-scored-v1-0-0.yaml
	modified:   centos-6-level-1-scored-v2-0-1.yaml
	modified:   centos-7-level-1-scored-v1-0-0.yaml
	modified:   centos-7-level-1-scored-v2-0-0.yaml
	modified:   centos-7-level-1-scored-v2-1-0.yaml
	modified:   coreos-level-1.yaml
	modified:   debian-7.yaml
	modified:   debian-8-level-1-scored-v1-0-0.yaml
	modified:   debian-9.yaml
	modified:   rhels-5-level-1-scored-v2-2-0.yaml
	modified:   rhels-6-level-1-scored-v1-0-0.yaml
	modified:   rhels-6-level-1-scored-v2-0-1.yaml
	modified:   rhels-7-level-1-scored-v1-0-0.yaml
	modified:   rhels-7-level-1-scored-v2-1-0.yaml
	modified:   rhelw-7-level-1-scored-v2-1-0.yaml
	modified:   ubuntu-1204-level-1-scored-v1-0-0.yaml
	modified:   ubuntu-1404-level-1-scored-v1-0-0.yaml
	modified:   ubuntu-1604-level-1-scored-v1-0-0.yaml